### PR TITLE
reinstate the 1T options, overwrite for nT

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,7 +1,6 @@
 from immutabledict import immutabledict
 import strax
 import straxen
-import numpy as np
 
 
 common_opts = dict(
@@ -46,6 +45,7 @@ xnt_common_config = dict(
         nveto_blank=(2999, 2999)),
     # Clustering/classification parameters
     s1_max_rise_time=100,
+    s2_xy_correction_map=("CMT_model", ('s2_xy_map', "ONLINE"), True),
 )
 
 # Plugins in these files have nT plugins, E.g. in pulse&peak(let)
@@ -242,6 +242,7 @@ x1t_common_config = dict(
     left_event_extension=int(1e6),
     right_event_extension=int(1e6),
 )
+
 
 
 def demo():

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -7,10 +7,12 @@ import strax
 import utilix
 import straxen
 import os
+
 export, __all__ = strax.exporter()
 
-corrections_w_file=['mlp_model', 'gcn_model', 'cnn_model', 's2_xy_map', 's1_xy_map',
-                    'fdc_map']
+corrections_w_file = ['mlp_model', 'gcn_model', 'cnn_model',
+                      's2_xy_map', 's1_xy_map', 'fdc_map']
+
 
 @export
 class CorrectionsManagementServices():
@@ -20,6 +22,7 @@ class CorrectionsManagementServices():
     stage to remove detector effects. Information on the strax implementation
     can be found at https://github.com/AxFoundation/strax/blob/master/strax/corrections.py
     """
+
     def __init__(self, username=None, password=None, mongo_url=None, is_nt=True):
         """
         :param username: corrections DB username
@@ -178,10 +181,10 @@ class CorrectionsManagementServices():
             # be cautious with very early runs, check that not all are None
             if np.isnan(to_pe).all():
                 raise ValueError(
-                        f'to_pe(PMT gains) values are NaN, no data available'
-                        f' for {run_id} in the gain model with version '
-                        f'{global_version}, please set constant values for '
-                        f'{run_id}')
+                    f'to_pe(PMT gains) values are NaN, no data available'
+                    f' for {run_id} in the gain model with version '
+                    f'{global_version}, please set constant values for '
+                    f'{run_id}')
 
         else:
             raise ValueError(f'{model_type} not implemented for to_pe values')
@@ -223,7 +226,7 @@ class CorrectionsManagementServices():
 
         file_name = self._get_correction(run_id, model_type, global_version)
 
-        if not file_name: 
+        if not file_name:
             raise ValueError(f"You have the right option but could not find a file"
                              f"Please contact CMT manager and yell at him")
 
@@ -242,8 +245,8 @@ class CorrectionsManagementServices():
             run_id = int(run_id)
 
         rundoc = self.collection.find_one(
-                {'number' if self.is_nt else 'name': run_id},
-                {'start': 1})
+            {'number' if self.is_nt else 'name': run_id},
+            {'start': 1})
         if rundoc is None:
             raise ValueError(f'run_id = {run_id} not found')
         time = rundoc['start']

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -59,13 +59,13 @@ def get_to_pe(run_id, gain_model, n_pmts):
             # Uniform gain, specified as a to_pe factor
             to_pe = np.ones(n_pmts, dtype=np.float32) * model_conf
         except np.core._exceptions.UFuncTypeError as e:
-            raise(str(e) +
-                  f'\nTried multiplying by {model_conf}. Insert a number instead.')
+            raise (str(e) +
+                   f'\nTried multiplying by {model_conf}. Insert a number instead.')
     else:
         raise NotImplementedError(f"Gain model type {model_type} not implemented")
 
     if len(to_pe) != n_pmts:
-       raise ValueError(
+        raise ValueError(
             f"Gain model {gain_model} resulted in a to_pe "
             f"of length {len(to_pe)}, but n_pmts is {n_pmts}!")
     return to_pe
@@ -109,8 +109,13 @@ def get_elife(run_id, elife_conf):
             '(model_type->str, model_config->str, is_nT->bool)'
             '')
     return e
+
+
 @export
 def get_config_from_cmt(run_id, conf):
+    if isinstance(conf, str) and conf.startswith('https://raw'):
+        # Legacy support for pax files
+        return conf
     if not isinstance(conf, tuple):
         raise ValueError(f'conf must be a tuple')
     if not len(conf) == 3:
@@ -121,7 +126,7 @@ def get_config_from_cmt(run_id, conf):
     if model_type == 'CMT_model':
         cmt = straxen.CorrectionsManagementServices(is_nt=is_nt)
         this_file = cmt.get_corrections_config(run_id, model_conf)
-        this_file = ' '.join(map(str, this_file))    
+        this_file = ' '.join(map(str, this_file))
 
     else:
         raise ValueError(f'Wrong NN configuration, please look at this {nn_config} '

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -367,10 +367,10 @@ class EventPositions(strax.Plugin):
             (first_sr1_run, pax_file('XENON1T_s1_xyz_lce_true_kr83m_SR1_pax-680_fdc-3d_v0.json'))]),  # noqa
     strax.Option(
         's2_xy_correction_map',
-        help="S2 (x, y) correction map. Correct S2 position dependence "
-             "manly due to bending of anode/gate-grid, PMT quantum efficiency "
-             "and extraction field distribution, as well as other geometric factors.",
-        default=("CMT_model", ('s2_xy_map', "ONLINE"), True)),
+        help="S2 relative LCE(x, y) map",
+        default_by_run=[
+            (0, pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json')),
+            (170118_1327, pax_file('XENON1T_s2_xy_ly_SR1_v2.2.json'))]),
    strax.Option(
         'elife_file',
         default=aux_repo + '3548132b55f81a43654dba5141366041e1daaf01/strax_files/elife.npy',

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -367,7 +367,9 @@ class EventPositions(strax.Plugin):
             (first_sr1_run, pax_file('XENON1T_s1_xyz_lce_true_kr83m_SR1_pax-680_fdc-3d_v0.json'))]),  # noqa
     strax.Option(
         's2_xy_correction_map',
-        help="S2 relative LCE(x, y) map",
+        help="S2 (x, y) correction map. Correct S2 position dependence "
+             "manly due to bending of anode/gate-grid, PMT quantum efficiency "
+             "and extraction field distribution, as well as other geometric factors.",
         default_by_run=[
             (0, pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json')),
             (170118_1327, pax_file('XENON1T_s2_xy_ly_SR1_v2.2.json'))]),

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,11 +1,9 @@
 import tempfile
 import strax
-import straxen
 import numpy as np
 from immutabledict import immutabledict
 from strax.testutils import run_id, recs_per_chunk
-import utilix
-import os
+import straxen
 
 # Number of chunks for the dummy raw records we are writing here
 N_CHUNKS = 2
@@ -24,7 +22,8 @@ testing_config_nT = dict(
     straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.h5',
     gain_model=
     ('to_pe_per_run',
-     straxen.aux_repo + '58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy')
+     straxen.aux_repo + '58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy'),
+    s2_xy_correction_map=straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json')
 )
 
 testing_config_1T = dict(
@@ -33,6 +32,7 @@ testing_config_1T = dict(
 )
 
 test_run_id_nT = '008900'
+
 
 @strax.takes_config(
     strax.Option('secret_time_offset', default=0, track=False)
@@ -192,6 +192,7 @@ def _test_child_options(st):
                 assert not t, (f'Found "{parent_name}" in the lineage of {p.__class__.__name__}. '
                                f'This should not have happend since "{parent_name}" is a child of '
                                f'"{option_name}"!')
+
 
 ##
 # Tests


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
This is a small patch PR to fix some issues for the 1T software in #382

**Can you briefly describe how it works?**
- Add legacy support for pax files necessary for 1T. This means not using CMT for options that have been working fine for 2 years now in 1T processing.
- I actually never realized but these annoying per_run_default options are a bit problematic. They are a cause of plural issues and it's why I'm very happy that for 1T, we use CMT 😄. I agree that *generally*  it is better to use the nT defaults at the definition of a plugin, and then overwrite the option in the 1T context. However, I don't know how to do it for these per run defaults: https://github.com/AxFoundation/strax/issues/400
- In case we don't have access to the database, we use an old pax file to test the software.

_I'm sorry for the few lines that are now PEP8-ed by my pycharm_: https://www.youtube.com/watch?v=wf-BqAjZb8M